### PR TITLE
refactor(garcedelete webhook): refactor garcedelete webhook with podd…

### DIFF
--- a/pkg/webhook/server/generic/pod/gracedelete/webhook.go
+++ b/pkg/webhook/server/generic/pod/gracedelete/webhook.go
@@ -19,7 +19,9 @@ package gracedelete
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -68,10 +70,10 @@ func (gd *GraceDelete) Validating(ctx context.Context, c client.Client, oldPod, 
 		if newPod.Labels == nil {
 			newPod.Labels = map[string]string{}
 		}
-		if newPod.Labels[appsv1alpha1.PodDeletionIndicationLabelKey] == "true" {
+		if _, ok := newPod.Labels[appsv1alpha1.PodDeletionIndicationLabelKey]; ok {
 			return nil
 		}
-		newPod.Labels[appsv1alpha1.PodDeletionIndicationLabelKey] = "true"
+		newPod.Labels[appsv1alpha1.PodDeletionIndicationLabelKey] = strconv.FormatInt(time.Now().Unix(), 10)
 
 		return c.Update(ctx, newPod)
 	})

--- a/pkg/webhook/server/generic/pod/gracedelete/webhook_test.go
+++ b/pkg/webhook/server/generic/pod/gracedelete/webhook_test.go
@@ -63,16 +63,46 @@ func TestGraceDelete(t *testing.T) {
 			oldPod: corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
-					Name:      "test2",
+					Name:      "test1",
+					Labels: map[string]string{
+						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey): "true",
+					},
 				},
 			},
+			keyWords:     "not found",
 			reqOperation: admissionv1.Delete,
 		},
 		{
 			fakePod: corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
-					Name:      "test",
+					Name:      "test2",
+					Labels: map[string]string{
+						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey): "true",
+						"operating.podopslifecycle.kusionstack.io/pod-delete": "1704865098763959176",
+					},
+				},
+			},
+			oldPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test2",
+					Labels: map[string]string{
+						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey): "true",
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				appsv1alpha1.PodDeletionIndicationLabelKey: "true",
+			},
+			keyWords:     "podOpsLifecycle denied",
+			reqOperation: admissionv1.Delete,
+		},
+		{
+			fakePod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test2",
 					Labels: map[string]string{
 						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey): "true",
 					},
@@ -81,10 +111,11 @@ func TestGraceDelete(t *testing.T) {
 			oldPod: corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
-					Name:      "test",
+					Name:      "test2",
 					Labels: map[string]string{
 						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey): "true",
 					},
+					Finalizers: []string{"prot.podopslifecycle.kusionstack.io/finalizer1,prot.podopslifecycle.kusionstack.io/finalizer2"},
 				},
 			},
 			expectedLabels: map[string]string{
@@ -98,11 +129,11 @@ func TestGraceDelete(t *testing.T) {
 			oldPod: corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
-					Name:      "test",
+					Name:      "test3",
 					Labels: map[string]string{
 						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey):      "true",
 						"operating.podopslifecycle.kusionstack.io/pod-delete":      "1704865098763959176",
-						"operation-type.podopslifecycle.kusionstack.io/pod-delete": "delete",
+						"operation-type.podopslifecycle.kusionstack.io/pod-delete": "1704865098763959336",
 						"operate.podopslifecycle.kusionstack.io/pod-delete":        "1704865212856080006",
 					},
 				},

--- a/pkg/webhook/server/generic/pod/gracedelete/webhook_test.go
+++ b/pkg/webhook/server/generic/pod/gracedelete/webhook_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kubectl/pkg/scheme"
 	"kusionstack.io/operating/apis/apps/v1alpha1"
-	"kusionstack.io/operating/pkg/controllers/poddeletion"
 	"kusionstack.io/operating/pkg/utils/feature"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -33,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	appsv1alpha1 "kusionstack.io/operating/apis/apps/v1alpha1"
 )
 
 func TestGraceDelete(t *testing.T) {
@@ -88,30 +88,22 @@ func TestGraceDelete(t *testing.T) {
 				},
 			},
 			expectedLabels: map[string]string{
-				fmt.Sprintf("%s/%s", v1alpha1.PodOperatingLabelPrefix, poddeletion.OpsLifecycleAdapter.GetID()):     "testvalue",
-				fmt.Sprintf("%s/%s", v1alpha1.PodOperationTypeLabelPrefix, poddeletion.OpsLifecycleAdapter.GetID()): "testvalue",
+				appsv1alpha1.PodDeletionIndicationLabelKey: "true",
 			},
 			keyWords:     "podOpsLifecycle denied",
 			reqOperation: admissionv1.Delete,
 		},
 		{
-			fakePod: corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "test",
-					Labels: map[string]string{
-						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey):                                         "true",
-						fmt.Sprintf("%s/%s", v1alpha1.PodOperateLabelPrefix, poddeletion.OpsLifecycleAdapter.GetID()): "true",
-					},
-				},
-			},
+			fakePod: corev1.Pod{},
 			oldPod: corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "test",
 					Labels: map[string]string{
-						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey):                                         "true",
-						fmt.Sprintf("%s/%s", v1alpha1.PodOperateLabelPrefix, poddeletion.OpsLifecycleAdapter.GetID()): "true",
+						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey):      "true",
+						"operating.podopslifecycle.kusionstack.io/pod-delete":      "1704865098763959176",
+						"operation-type.podopslifecycle.kusionstack.io/pod-delete": "delete",
+						"operate.podopslifecycle.kusionstack.io/pod-delete":        "1704865212856080006",
 					},
 				},
 			},


### PR DESCRIPTION
…eletion_controller

<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):
- [x] N

#### 2. What is the scope of this PR (e.g. component or file name):
pkg/webhook/server/generic/pod/gracedelete

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):
- [ ] Affects user behaviors
- [ ] Contains experimental features

The garcedelete webhook is refactored in this PR, to fix that The sts workload is not supported in last version.  
In this PR,  pod deletion requests are intercepted by the garcedelete webhook firstly, and then label pod to trigger poddeletion_controlelr reconcile.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):
- [ ] N

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:
- [ ] Unit test

#### 6. Release note
```release-note
None
```
