### PR TITLE
fix: gracedelete webhook compatible in the absence of ServiceReadyReadinessGate

### DIFF
--- a/pkg/webhook/server/generic/pod/gracedelete/webhook.go
+++ b/pkg/webhook/server/generic/pod/gracedelete/webhook.go
@@ -55,6 +55,20 @@ func (gd *GraceDelete) Validating(ctx context.Context, c client.Client, oldPod, 
 		return nil
 	}
 
+	// if has no service-ready ReadinessGate, skip gracedelete
+	hasReadinessGate := false
+	if oldPod.Spec.ReadinessGates != nil {
+		for _, readinessGate := range oldPod.Spec.ReadinessGates {
+			if readinessGate.ConditionType == v1alpha1.ReadinessGatePodServiceReady {
+				hasReadinessGate = true
+				break
+			}
+		}
+	}
+	if !hasReadinessGate {
+		return nil
+	}
+
 	// if pod is allowed to delete
 	if _, allowed := podopslifecycle.AllowOps(poddeletion.OpsLifecycleAdapter, 0, oldPod); allowed {
 		return nil

--- a/pkg/webhook/server/generic/pod/gracedelete/webhook_test.go
+++ b/pkg/webhook/server/generic/pod/gracedelete/webhook_test.go
@@ -63,6 +63,24 @@ func TestGraceDelete(t *testing.T) {
 			oldPod: corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
+					Name:      "test",
+					Labels: map[string]string{
+						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey): "true",
+					},
+				},
+			},
+			reqOperation: admissionv1.Delete,
+		},
+		{
+			fakePod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test",
+				},
+			},
+			oldPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
 					Name:      "test1",
 					Labels: map[string]string{
 						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey): "true",

--- a/pkg/webhook/server/generic/pod/gracedelete/webhook_test.go
+++ b/pkg/webhook/server/generic/pod/gracedelete/webhook_test.go
@@ -68,6 +68,9 @@ func TestGraceDelete(t *testing.T) {
 						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey): "true",
 					},
 				},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{{ConditionType: v1alpha1.ReadinessGatePodServiceReady}},
+				},
 			},
 			keyWords:     "not found",
 			reqOperation: admissionv1.Delete,
@@ -90,6 +93,9 @@ func TestGraceDelete(t *testing.T) {
 					Labels: map[string]string{
 						fmt.Sprintf(v1alpha1.ControlledByKusionStackLabelKey): "true",
 					},
+				},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{{ConditionType: v1alpha1.ReadinessGatePodServiceReady}},
 				},
 			},
 			expectedLabels: map[string]string{
@@ -117,6 +123,9 @@ func TestGraceDelete(t *testing.T) {
 					},
 					Finalizers: []string{"prot.podopslifecycle.kusionstack.io/finalizer1,prot.podopslifecycle.kusionstack.io/finalizer2"},
 				},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{{ConditionType: v1alpha1.ReadinessGatePodServiceReady}},
+				},
 			},
 			expectedLabels: map[string]string{
 				appsv1alpha1.PodDeletionIndicationLabelKey: "true",
@@ -137,7 +146,11 @@ func TestGraceDelete(t *testing.T) {
 						"operate.podopslifecycle.kusionstack.io/pod-delete":        "1704865212856080006",
 					},
 				},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{{ConditionType: v1alpha1.ReadinessGatePodServiceReady}},
+				},
 			},
+
 			reqOperation: admissionv1.Delete,
 		},
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):
- [ ] N

#### 2. What is the scope of this PR (e.g. component or file name):
pkg/webhook/server/generic/pod/gracedelete

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains experimental features

Limit the effective scope of gracedelete webhook, considering the pod without service-ready ReadinessGate.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):
- [ ] N

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:
- [ ] Unit test

#### 6. Release note
```release-note
None
```
