### PR TITLE
Fix: delay clear pd finalizer and delete invalid printcolumn 

### DIFF
--- a/apis/apps/v1alpha1/poddecoration_types.go
+++ b/apis/apps/v1alpha1/poddecoration_types.go
@@ -265,7 +265,6 @@ type PodDecorationCondition struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=pd
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="EFFECTIVE",type="boolean",JSONPath=".status.isEffective",description="The number of pods updated."
 // +kubebuilder:printcolumn:name="MATCHED",type="integer",JSONPath=".status.matchedPods",description="The number of selected pods."
 // +kubebuilder:printcolumn:name="INJECTED",type="integer",JSONPath=".status.injectedPods",description="The number of injected pods."
 // +kubebuilder:printcolumn:name="UPDATED",type="integer",JSONPath=".status.updatedPods",description="The number of updated pods."

--- a/charts/templates/crd/apps.kusionstack.io_poddecorations.yaml
+++ b/charts/templates/crd/apps.kusionstack.io_poddecorations.yaml
@@ -18,10 +18,6 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The number of pods updated.
-      jsonPath: .status.isEffective
-      name: EFFECTIVE
-      type: boolean
     - description: The number of selected pods.
       jsonPath: .status.matchedPods
       name: MATCHED

--- a/config/crd/bases/apps.kusionstack.io_poddecorations.yaml
+++ b/config/crd/bases/apps.kusionstack.io_poddecorations.yaml
@@ -18,10 +18,6 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The number of pods updated.
-      jsonPath: .status.isEffective
-      name: EFFECTIVE
-      type: boolean
     - description: The number of selected pods.
       jsonPath: .status.matchedPods
       name: MATCHED


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references: 

- [x] N
- [ ] Y 

#### 2. What is the scope of this PR (e.g. component or file name):
PodDecoration

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):
Fix:
1. Delay clear pd finalizer: delete finalizer after all pods escape to ensure cls get old pd controllerrevision.
2. Delete poddecoration 'EFFECTIVE' printcolumn 

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
